### PR TITLE
Version 0.3.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,22 @@
 # Trigger Changelog
 
+## 0.3.0 - 2019-11-12
+NOTE: this update modifies the database and resets the database schema. A one-time uninstall and reinstall of the plugin will add the new database table. 
+
+### Added
+- Added support for Craft sites that use Project Config.
+  - Added `%trigger_status` table to the database.
+  - Moved `shouldDeploy` from Trigger settings to `%trigger_status` table, as the `status` column.
+- Added ability to deploy on element changes.
+  - Added `deployOnContentChange` setting to enable this.
+- Trigger deployment (or change trigger status) on move of content in a structure and when saving globals.
+- Added override of `devMode` check to allow for deployments after content changes while in `devMode`.
+  - NOTE: to enable this, create a `./config/trigger.php` file and set `devModeDeploy` to `true`.
+
+### Changed
+- Deployments can be triggered for all element types.
+- Ignore possible Triggers when element is both a draft or revision.
+
 ## 0.2.0 - 2019-10-27
 ### Added
 - Added a Dashboard widget for instantly triggering builds.

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "workingconcept/craft-trigger",
     "description": "Utility for triggering deployments when they're needed.",
     "type": "craft-plugin",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "keywords": [
         "craft",
         "cms",

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Trigger plugin for Craft CMS 3.x
+ *
+ * @link      https://workingconcept.com
+ * @copyright Copyright (c) 2019 Working Concept Inc.
+ */
+
+namespace workingconcept\trigger\migrations;
+
+use workingconcept\trigger\Trigger;
+
+use Craft;
+use craft\config\DbConfig;
+use craft\db\Migration;
+
+/**
+ * @author    Working Concept Inc.
+ * @package   Trigger
+ * @since     0.3.0
+ */
+class Install extends Migration
+{
+    // Public Properties
+    // =========================================================================
+
+    /**
+     * @var string The database driver to use
+     */
+    public $driver;
+
+    // Public Methods
+    // =========================================================================
+
+    /**
+     * @inheritdoc
+     */
+    public function safeUp()
+    {
+        $this->driver = Craft::$app->getConfig()->getDb()->driver;
+        if ($this->createTables()) {
+            // Refresh the db schema caches
+            Craft::$app->db->schema->refresh();
+        }
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown()
+    {
+        $this->driver = Craft::$app->getConfig()->getDb()->driver;
+        $this->removeTables();
+
+        return true;
+    }
+
+    // Protected Methods
+    // =========================================================================
+
+    /**
+     * @return bool
+     */
+    protected function createTables()
+    {
+        $tablesCreated = false;
+
+        $tableSchema = Craft::$app->db->schema->getTableSchema('{{%trigger_status}}');
+        if ($tableSchema === null) {
+            $tablesCreated = true;
+            $this->createTable(
+                '{{%trigger_status}}',
+                [
+                    'id' => $this->primaryKey(),
+                    'dateCreated' => $this->dateTime()->notNull(),
+                    'dateUpdated' => $this->dateTime()->notNull(),
+                    'uid' => $this->uid(),
+                    'status' => $this->string(11)->notNull()->defaultValue('idle'),
+                ]
+            );
+        }
+
+        return $tablesCreated;
+    }
+
+    /**
+     * @return void
+     */
+    protected function removeTables()
+    {
+        $this->dropTableIfExists('{{%trigger_status}}');
+    }
+}

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -29,7 +29,12 @@ class Settings extends Model
     public $active = true;
 
     /**
-     * @var bool Flag that determines whether build should be triggered on check.
+     * @var bool Automatically deploy on content change
      */
-    public $shouldDeploy = false;
+    public $deployOnContentChange = true;
+
+    /**
+     * @var bool Allow deployments when DevMode is turned on
+     */
+    public $devModeDeploy = false;
 }

--- a/src/models/Status.php
+++ b/src/models/Status.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Trigger plugin for Craft CMS 3.x
+ *
+ * @link      https://workingconcept.com
+ * @copyright Copyright (c) 2019 Working Concept Inc.
+ */
+
+namespace workingconcept\trigger\models;
+
+use workingconcept\trigger\Trigger;
+
+use Craft;
+use craft\base\Model;
+
+/**
+ * @author    Working Concept Inc.
+ * @package   Trigger
+ * @since     0.3.0
+ */
+class Status extends Model
+{
+    // Public Properties
+    // =========================================================================
+
+    /**
+     * @var string
+     */
+    public $status = 'idle';
+
+    // Public Methods
+    // =========================================================================
+
+    /**
+     * @inheritdoc
+     */
+    public function rules()
+    {
+        return [
+            ['status', 'string'],
+            ['status', 'default', 'value' => 'idle'],
+        ];
+    }
+}

--- a/src/records/Status.php
+++ b/src/records/Status.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Trigger plugin for Craft CMS 3.x
+ *
+ * @link      https://workingconcept.com
+ * @copyright Copyright (c) 2019 Working Concept Inc.
+ */
+
+namespace workingconcept\trigger\records;
+
+use workingconcept\trigger\Trigger;
+
+use Craft;
+use craft\db\ActiveRecord;
+
+/**
+ * @author    Working Concept Inc.
+ * @package   Trigger
+ * @since     0.3.0
+ */
+class Status extends ActiveRecord
+{
+    // Public Static Methods
+    // =========================================================================
+
+    /**
+     * @inheritdoc
+     */
+    public static function tableName()
+    {
+        return '{{%trigger_status}}';
+    }
+}

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -14,7 +14,7 @@
 }) }}
 
 {{ forms.lightswitchField({
-    label: 'Active'|t,
+    label: 'Active' | translate( 'trigger' ),
     id: 'active',
     required: false,
     name: 'active',
@@ -24,11 +24,11 @@
 }) }}
 
 {{ forms.lightswitchField({
-    label: 'Deploy Waiting'|t,
-    id: 'shouldDeploy',
+    label: 'Deploy on Content Change' | translate( 'trigger' ),
+    id: 'deployOnContentChange',
     required: false,
-    name: 'shouldDeploy',
-    on: settings.shouldDeploy,
-    errors: settings.getErrors('shouldDeploy'),
-    instructions: 'Flip on to trigger a deploy on the next check, or off to cancel a pending deploy.' | translate( 'trigger' ),
+    name: 'deployOnContentChange',
+    on: settings.deployOnContentChange,
+    errors: settings.getErrors('deployOnContentChange'),
+    instructions: 'Automatically trigger a deployment after content changes.' | translate( 'trigger' ),
 }) }}


### PR DESCRIPTION
Hey @mattstein!

In this PR I'm adding support for projects that use Project Config files, but this means that the `shouldDeploy` setting and how it was being used needed to be changed to a different place in the database. Because of this, I added database tables to manage the status, but the simplest way to get that working is to re-install the plugin in your Craft site (adding a migration could have worked, but this keeps the schema version in line with the plugin version number).

I also added a setting that lets the plugin trigger a deployment upon content changes (including moving content in Structures and on updating Globals content). I realize this isn't exactly the intention of this plugin, but it makes it simpler than having 2 plugins if a developer wants the features of both Trigger and Webhooks for a project.

Finally, I opened it up to trigger a deployment or flag the status for the next deployment for all element types. That way it shouldn't matter if a category is changing or a custom element type is updated. This may warrant a config setting, but I can't think of a time where an element changing shouldn't re-build the site (except maybe User elements).


Here's a list of changes below (as per the Changelog.md file):

- Added support for Craft sites that use Project Config.
  - Added `%trigger_status` table to the database.
  - Moved `shouldDeploy` from Trigger settings to `%trigger_status` table, as the `status` column.
- Added ability to deploy on element changes.
  - Added `deployOnContentChange` setting to enable this.
- Trigger deployment (or change trigger status) on move of content in a structure and when saving globals.
- Added override of `devMode` check to allow for deployments after content changes while in `devMode`.
  - NOTE: to enable this, create a `./config/trigger.php` file and set `devModeDeploy` to `true`.


Let me know if you want to discuss any of these changes.

Thanks,
Will