### PR TITLE
change GlobalSetContentEvent to GlobalSetEvent, remove unused imports

### DIFF
--- a/src/Trigger.php
+++ b/src/Trigger.php
@@ -16,12 +16,10 @@ use Craft;
 use craft\console\Application as ConsoleApplication;
 use craft\base\Plugin;
 use craft\events\ElementEvent;
-use craft\events\GlobalSetContentEvent;
+use craft\events\GlobalSetEvent;
 use craft\events\RegisterComponentTypesEvent;
-use craft\helpers\ElementHelper;
 use craft\services\Dashboard;
 use craft\services\Elements;
-use craft\elements\Entry;
 use craft\services\Globals;
 use yii\base\Event;
 
@@ -124,7 +122,7 @@ class Trigger extends Plugin
             Event::on(
                 Globals::class,
                 Globals::EVENT_AFTER_SAVE_GLOBAL_SET,
-                function (GlobalSetContentEvent $event) {
+                function (GlobalSetEvent $event) {
                     $this->deployments->checkElement($event->globalSet);
                 }
             );


### PR DESCRIPTION
In craft 3.4.18, the type passed to this closure is `GlobalSetEvent` instead of `GlobalSetContentEvent`, which throws an error. 

`error: Argument 1 passed to workingconcept\trigger\Trigger::workingconcept\trigger\{closure}() must be an instance of craft\events\GlobalSetContentEvent, instance of craft\events\GlobalSetEvent given`